### PR TITLE
Fix some bug in atlas_rag

### DIFF
--- a/atlas_rag/evaluation/benchmark.py
+++ b/atlas_rag/evaluation/benchmark.py
@@ -195,9 +195,9 @@ class RAGBenchmark:
             average_recall_2 = sum([result[f"{retriever_name}_recall@2"] for result in result_list]) / len(result_list)
             average_recall_5 = sum([result[f"{retriever_name}_recall@5"] for result in result_list]) / len(result_list)
             summary_dict.update( {
-                "average_f1": average_f1,
-                "average_em": average_em,
-                "average_recall@2": average_recall_2,
-                "average_recall@5": average_recall_5,
+                f"{retriever_name}_average_f1": average_f1,
+                f"{retriever_name}_average_em": average_em,
+                f"{retriever_name}_average_recall@2": average_recall_2,
+                f"{retriever_name}_average_recall@5": average_recall_5,
             })
         return summary_dict

--- a/atlas_rag/reader/llm_generator.py
+++ b/atlas_rag/reader/llm_generator.py
@@ -128,19 +128,19 @@ class LLMGenerator():
         # return self._generate_response(messages, max_new_tokens=max_new_tokens, frequency_penalty=frequency_penalty, temperature = temperature, seed = seed)
         return self._generate_response(messages, max_new_tokens=max_new_tokens, temperature = temperature)
 
-    def generate_with_context_one_shot(self, question, context, max_new_tokens=4096):
+    def generate_with_context_one_shot(self, question, context, max_new_tokens=4096, frequency_penalty=None, temperature = 0.7, seed = None):
         messages = deepcopy(prompt_template)
         messages.append(
             {"role": "user", "content": f"{context}\n\nQuestions:{question}\nThought:"},
             
         )
-        return self._generate_response(messages, max_new_tokens=max_new_tokens)
-    def generate_with_context_kg(self, question, context, max_new_tokens=1024):
+        return self._generate_response(messages, max_new_tokens=max_new_tokens, temperature = temperature)
+    def generate_with_context_kg(self, question, context, max_new_tokens=1024, frequency_penalty=None, temperature = 0.7, seed = None):
         messages = [
             {"role": "system", "content": self.cot_system_instruction_kg},
             {"role": "user", "content": f"{context}\n\n{question}"},
         ]
-        return self._generate_response(messages, max_new_tokens=max_new_tokens)
+        return self._generate_response(messages, max_new_tokens=max_new_tokens, temperature = temperature)
 
     def filter_triples_with_entity(self,question, nodes, max_new_tokens=1024):
         messages = [

--- a/atlas_rag/retrieval/retriever/simple_retriever.py
+++ b/atlas_rag/retrieval/retriever/simple_retriever.py
@@ -19,11 +19,11 @@ class SimpleGraphRetriever(BaseEdgeRetriever):
         self.edge_faiss_index = data["edge_faiss_index"]
 
 
-    def retrieve(self, query, topk=5, **kwargs):
+    def retrieve(self, query, topN=5, **kwargs):
         # retrieve the top k edges
         topk_edges = []
         query_embedding = self.sentence_encoder.encode([query], query_type='edge')
-        D, I = self.edge_faiss_index.search(query_embedding, topk)
+        D, I = self.edge_faiss_index.search(query_embedding, topN)
 
         topk_edges += [self.edge_list[i] for i in I[0]]
 
@@ -40,10 +40,10 @@ class SimpleTextRetriever(BasePassageRetriever):
         self.passage_keys = list(passage_dict.keys())
         self.text_embeddings = data["text_embeddings"]
         
-    def retrieve(self, query, topk=5, **kwargs):
+    def retrieve(self, query, topN=5, **kwargs):
         query_emb = self.sentence_encoder.encode([query], query_type="passage")
         sim_scores = self.text_embeddings @ query_emb[0].T
-        topk_indices = np.argsort(sim_scores)[-topk:][::-1]  # Get indices of top-k scores
+        topk_indices = np.argsort(sim_scores)[-topN:][::-1]  # Get indices of top-k scores
 
         # Retrieve top-k passages
         topk_passages = [self.passage_list[i] for i in topk_indices]


### PR DESCRIPTION
## ***Issues***
1. Static key's name while saving the results of atlas_rag in `atlas_rag/evaluation/benchmark.py`.
2. The parameters of LLM generation is inconsistent in different functions in `atlas_rag/reader/llm_generator.py`.
3. The parameter name `topk` in `atlas_rag/retrieval/retriever/simple_retriever.py` is inconsistent with the `topN` in benchmark.py and other retrievers.