### PR TITLE
Added newline param to all file write CSV calls

### DIFF
--- a/EvaluateKGC/SchemaQuality/conceptualization_contextulized_api.py
+++ b/EvaluateKGC/SchemaQuality/conceptualization_contextulized_api.py
@@ -210,7 +210,7 @@ async def generate_entity_concepts(args):
         pred_entity_concept[entity].extend([x.strip().lower() for x in answer.split(",")])
 
     # write the generation resutls
-    with open(output_file, "w") as file:
+    with open(output_file, "w", newline='') as file:
         # write to csv
         csv_writer = csv.writer(file)
         csv_writer.writerow(["node", "conceptualized_node", "node_type"])
@@ -263,7 +263,7 @@ async def generate_relation_concepts(args):
         pred_relation_concept[event].extend([x.strip().lower() for x in answer.split(",")])
 
     # write the generation resutls
-    with open(output_file, "w") as file:
+    with open(output_file, "w", newline='') as file:
         # write to csv
         csv_writer = csv.writer(file)
         csv_writer.writerow(["node", "conceptualized_node", "node_type"])
@@ -307,7 +307,7 @@ async def generate_event_concepts(args):
         pred_event_concept[event].extend([x.strip().lower() for x in answer.split(",")])
 
     # write the generation resutls
-    with open(output_file, "w") as file:
+    with open(output_file, "w", newline='') as file:
         # write to csv
         csv_writer = csv.writer(file)
         csv_writer.writerow(["node", "conceptualized_node", "node_type"])

--- a/atlas_rag/kg_construction/concept_generation.py
+++ b/atlas_rag/kg_construction/concept_generation.py
@@ -167,7 +167,7 @@ def generate_concept(model: LLMGenerator,
 
     
     output_file = output_folder + f"/{output_file.rsplit('.', 1)[0]}_shard_{shard}.csv"
-    with open(output_file, "w") as file:
+    with open(output_file, "w", newline='') as file:
         csv_writer = csv.writer(file)
         csv_writer.writerow(["node", "conceptualized_node", "node_type"])
 

--- a/atlas_rag/kg_construction/utils/csv_processing/csv_add_numeric_id.py
+++ b/atlas_rag/kg_construction/utils/csv_processing/csv_add_numeric_id.py
@@ -34,7 +34,7 @@ def check_created_csv_header(keyword, csv_dir):
                     break
 
 def add_csv_columns(node_csv, edge_csv, text_csv, node_with_numeric_id, edge_with_numeric_id, text_with_numeric_id):
-    with open(node_csv) as infile, open(node_with_numeric_id, 'w') as outfile:
+    with open(node_csv) as infile, open(node_with_numeric_id, 'w', newline='') as outfile:
         reader = csv.reader(infile)
         writer = csv.writer(outfile)
         header = next(reader)
@@ -45,7 +45,7 @@ def add_csv_columns(node_csv, edge_csv, text_csv, node_with_numeric_id, edge_wit
         for row_number, row in tqdm(enumerate(reader), desc="Adding numeric ID"):
             row.insert(label_index, row_number)  # Add numeric ID before ':LABEL'
             writer.writerow(row)
-    with open(edge_csv) as infile, open(edge_with_numeric_id, 'w') as outfile:
+    with open(edge_csv) as infile, open(edge_with_numeric_id, 'w', newline='') as outfile:
         reader = csv.reader(infile)
         writer = csv.writer(outfile)
         header = next(reader)
@@ -56,7 +56,7 @@ def add_csv_columns(node_csv, edge_csv, text_csv, node_with_numeric_id, edge_wit
         for row_number, row in tqdm(enumerate(reader), desc="Adding numeric ID"):
             row.insert(label_index, row_number)  # Add numeric ID before ':LABEL'
             writer.writerow(row)
-    with open(text_csv) as infile, open(text_with_numeric_id, 'w') as outfile:
+    with open(text_csv) as infile, open(text_with_numeric_id, 'w', newline='') as outfile:
         reader = csv.reader(infile)
         writer = csv.writer(outfile)
         header = next(reader)

--- a/atlas_rag/kg_construction/utils/json_processing/json_to_csv.py
+++ b/atlas_rag/kg_construction/utils/json_processing/json_to_csv.py
@@ -69,10 +69,10 @@ def json2csv(dataset, data_dir, output_dir, test=False):
         missing_concepts_file = os.path.join(output_dir, f"missing_concepts_{dataset}_from_json_test.csv")
 
     # Open CSV files for writing
-    with open(node_text_file, "w", encoding='utf-8', errors='ignore') as csvfile_node_text, \
-         open(edge_text_file, "w", encoding='utf-8', errors='ignore') as csvfile_edge_text, \
-         open(node_csv_without_emb, "w", encoding='utf-8', errors='ignore') as csvfile_node, \
-         open(edge_csv_without_emb, "w", encoding='utf-8', errors='ignore') as csvfile_edge:
+    with open(node_text_file, "w", newline='', encoding='utf-8', errors='ignore') as csvfile_node_text, \
+         open(edge_text_file, "w", newline='', encoding='utf-8', errors='ignore') as csvfile_edge_text, \
+         open(node_csv_without_emb, "w", newline='', encoding='utf-8', errors='ignore') as csvfile_node, \
+         open(edge_csv_without_emb, "w", newline='', encoding='utf-8', errors='ignore') as csvfile_edge:
 
         csv_writer_node_text = csv.writer(csvfile_node_text)
         csv_writer_edge_text = csv.writer(csvfile_edge_text)
@@ -255,7 +255,7 @@ def json2csv(dataset, data_dir, output_dir, test=False):
                         writer_edge.writerow([head_event, tail_entity, relation, [], [], "Relation"])
 
     # Write missing concepts to CSV
-    with open(missing_concepts_file, "w", encoding='utf-8', errors='ignore') as csvfile:
+    with open(missing_concepts_file, "w", newline='', encoding='utf-8', errors='ignore') as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(["Name", "Type"])
         for entity in all_entities:

--- a/atlas_rag/vectorstore/embedding_model.py
+++ b/atlas_rag/vectorstore/embedding_model.py
@@ -15,7 +15,7 @@ class BaseEmbeddingModel(ABC):
     
     def compute_kg_embedding(self, node_csv_without_emb, node_csv_file, edge_csv_without_emb, edge_csv_file, text_node_csv_without_emb, text_node_csv, **kwargs):
         with open(node_csv_without_emb, "r") as csvfile_node:
-            with open(node_csv_file, "w") as csvfile_node_emb:
+            with open(node_csv_file, "w", newline='') as csvfile_node_emb:
                 reader_node = csv.reader(csvfile_node)
 
                 # the reader has [name:ID,type,concepts,synsets,:LABEL]
@@ -56,7 +56,7 @@ class BaseEmbeddingModel(ABC):
         
 
         with open(edge_csv_without_emb, "r") as csvfile_edge:
-            with open(edge_csv_file, "w") as csvfile_edge_emb:
+            with open(edge_csv_file, "w", newline='') as csvfile_edge_emb:
                 reader_edge = csv.reader(csvfile_edge)
                 # [":START_ID",":END_ID","relation","concepts","synsets",":TYPE"]
                 writer_edge = csv.writer(csvfile_edge_emb)
@@ -92,7 +92,7 @@ class BaseEmbeddingModel(ABC):
         
 
         with open(text_node_csv_without_emb, "r") as csvfile_text_node:
-            with open(text_node_csv, "w") as csvfile_text_node_emb:
+            with open(text_node_csv, "w", newline='') as csvfile_text_node_emb:
                 reader_text_node = csv.reader(csvfile_text_node)
                 # [text_id:ID,original_text,:LABEL]
                 writer_text_node = csv.writer(csvfile_text_node_emb)


### PR DESCRIPTION
Added newline parameter to all CSV writing open() calls.

On Windows, Python will automatically translate \n to \r\n, and then the csv module will add another \r, resulting in blank lines between rows in the output file.